### PR TITLE
make py-microservices use *args / **kwargs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 .brev
 **/.pytest_cache/
 **/Pipfile*
+__pycache__
+*.pyc

--- a/py-microservices/app/main.py
+++ b/py-microservices/app/main.py
@@ -24,6 +24,33 @@ async def read_item(user_id: str):
 
 
 @app.post("/users/{user_id}", response_class=PlainTextResponse)
-async def write_user(user_id: str):
-    await post_user(user_id)
+async def write_user(user_id: str, tags: str=''):
+    '''
+    Upserts a user. The tags are comma-delimited, and come in two forms, which you can mix and match:
+    
+    - "flat" tags, which are just the tag name
+    - "value" tags, which come in name=value format
+
+    For example, /users/alice?tags=foo,bar,hello=world would create three tags:
+
+    - "foo" (a flat tag)
+    - "bar" (a flat tag)
+    - "hello" => "world" (a value tag)
+    ''' 
+    flat_tags, value_tags = _parse_tags(tags)
+    await post_user(user_id, *flat_tags, **value_tags)
     return f"Created {user_id}"
+
+def _parse_tags(tags: str) -> (list[str], dict[str, str]):
+    flat_tags = []
+    value_tags = {}
+    for tag in tags.split(','):
+        if not tag:
+            continue # ignore blank tags
+        segments = tag.split('=', 1) # separate the tag by its first comma, if present
+        if len(segments) == 1:
+            flat_tags.append(tag)
+        else:
+            name, value = segments
+            value_tags[name] = value
+    return flat_tags, value_tags

--- a/py-microservices/app/model.py
+++ b/py-microservices/app/model.py
@@ -11,19 +11,25 @@ from datetime import datetime
 # }
 __users = Cache(Cache.MEMORY)
 
-
 async def get_user(id: str):
-    last_access_ts = await __users.get(id, default=False)
-    if not last_access_ts:
+    user_info = await __users.get(id, default=False)
+    if not user_info:
         return None
-    # aiocache turns last_access_ts into a decimal.Decimal, so convert it back to a float
-    last_access_dt = datetime.fromtimestamp(float(last_access_ts))
-    last_access_iso = last_access_dt.isoformat(timespec='seconds')
+    # aiocache turns the "created"timestamp into a decimal.Decimal, so convert it back to a float
+    created_dt = datetime.fromtimestamp(float(user_info["created"]))
+    created_iso = created_dt.isoformat(timespec='seconds')
     return {
         "id": id,
-        "last_accessed": last_access_iso
+        "created": created_iso,
+        "tags": user_info["tags"]
     }
 
 
-async def post_user(id: str):
-    await __users.set(id, datetime.utcnow().timestamp())
+async def post_user(id: str, *flat_tags: str, **value_tags: str):
+    await __users.set(id, {
+        "created": datetime.utcnow().timestamp(),
+        "tags": {
+            "flat": flat_tags,
+            "value": value_tags,
+        },
+    })

--- a/py-microservices/test/integration_tests.py
+++ b/py-microservices/test/integration_tests.py
@@ -6,7 +6,7 @@ apiEndpoint = os.environ.get("API_ENDPOINT", 'http://localhost:3000')
 
 
 def test_add_user():
-    actual_put_response = requests.post(f"{apiEndpoint}/users/{test_username}")
+    actual_put_response = requests.post(f"{apiEndpoint}/users/{test_username}?tags=one,two,hello=world")
     expected_put_response = f"Created {test_username}"
     assert actual_put_response.text == expected_put_response
 
@@ -15,3 +15,9 @@ def test_get_user():
     actual_get_response = requests.get(f"{apiEndpoint}/users/{test_username}")
     actual_user = actual_get_response.json()
     assert actual_user["id"] == test_username
+    assert actual_user["tags"] == {
+        "flat": ["one", "two"],
+        "value": {
+            "hello": "world"
+        }
+    }


### PR DESCRIPTION
To do this, I added a simple tagging system to POST user. It's a bit contrived, but it does the job. :-)

Requires changes in klotho and klotho-pro; PRs coming in a sec.